### PR TITLE
Removed the eligibility checks for child benefits and fixed tests

### DIFF
--- a/__tests__/components/benefit_expansion_test.js
+++ b/__tests__/components/benefit_expansion_test.js
@@ -47,12 +47,12 @@ describe("BenefitExpansion", () => {
     expect(await axe(html)).toHaveNoViolations();
   });
 
-  it("contains the 2 ChildBenefitList components", () => {
+  it("contains the ChildBenefitList component", () => {
     expect(
       mount(<BenefitExpansion {...props} {...reduxData} />).find(
         "ChildBenefitList"
       ).length
-    ).toEqual(2);
+    ).toEqual(1);
   });
 
   describe("getAlsoEligibleBenefits", () => {
@@ -75,20 +75,6 @@ describe("BenefitExpansion", () => {
         "Treatment Benefits",
         "Veterans Independence Program"
       ]);
-    });
-
-    it("returns the correct family benefits", () => {
-      const childBenefits = props.benefit.childBenefits
-        ? reduxData.benefits.filter(
-            ab => props.benefit.childBenefits.indexOf(ab.id) > -1
-          )
-        : [];
-      expect(
-        mount(<BenefitExpansion {...props} {...reduxData} />)
-          .instance()
-          .getAlsoEligibleBenefits(childBenefits, "family")
-          .map(x => x.benefitNameEn)
-      ).toEqual([]);
     });
   });
 });

--- a/components/benefit_expansion.js
+++ b/components/benefit_expansion.js
@@ -26,17 +26,6 @@ export class BenefitExpansion extends Component {
       JSON.stringify(getProfileFilters(reduxState, this.props))
     );
 
-    if (patronType === "family") {
-      // the following code exists because we don't ask veterans/servingMembers the statusAndVitals question
-      switch (profileFilters["patronType"]) {
-        case "veteran":
-          profileFilters["statusAndVitals"] = "releasedAlive";
-          break;
-        case "servingMember":
-          profileFilters["statusAndVitals"] = "stillServing";
-          break;
-      }
-    }
     const selectedNeeds = {}; // we don't want to filter by need here
     if (patronType !== "") {
       profileFilters["patronType"] = patronType;
@@ -53,30 +42,13 @@ export class BenefitExpansion extends Component {
   };
 
   render() {
-    const { t, benefit, benefits, reduxState, store } = this.props;
+    const { t, benefit, benefits, store } = this.props;
     const language = t("current-language-code");
     const benefitName =
       language === "en" ? benefit.benefitNameEn : benefit.benefitNameFr;
     const childBenefits = benefit.childBenefits
       ? benefits.filter(ab => benefit.childBenefits.indexOf(ab.id) > -1)
       : [];
-
-    const veteranBenefits = this.getAlsoEligibleBenefits(
-      childBenefits,
-      "veteran"
-    );
-    const servingMemberBenefits = this.getAlsoEligibleBenefits(
-      childBenefits,
-      "servingMember"
-    );
-    const vetServBenefits =
-      reduxState.statusAndVitals !== "deceased"
-        ? [...new Set(veteranBenefits.concat(servingMemberBenefits))]
-        : [];
-    const familyBenefits = this.getAlsoEligibleBenefits(
-      childBenefits,
-      "family"
-    );
 
     let otherBenefits = t("benefits_b.eligible_open_veteran", {
       x: benefitName
@@ -91,13 +63,8 @@ export class BenefitExpansion extends Component {
           language={language}
         />
         <ChildBenefitList
-          benefits={vetServBenefits}
+          benefits={childBenefits}
           colonText={otherBenefits}
-          t={t}
-        />
-        <ChildBenefitList
-          benefits={familyBenefits}
-          colonText={t("benefits_b.eligible_open_family")}
           t={t}
         />
       </div>


### PR DESCRIPTION
Closes #44 

I figured the easiest way to do this was to just remove the eligibility checks for child benefits since this is VAC specific logic. This is actually the way the VAC app was until relatively recently.